### PR TITLE
Update pdf_extractor requirements.txt [Library fixes]

### DIFF
--- a/pdf_extractor/requirements.txt
+++ b/pdf_extractor/requirements.txt
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-git+https://github.com/dscarvalho/pdf_extract.git@v0.1.3
+git+https://github.com/dscarvalho/pdf_extract.git@v0.1.4


### PR DESCRIPTION
Found new parsing errors coming from the Adobe pdfservices library.
They are now being covered by the wrapper.