### PR TITLE
Check returned doc_info from extractor for parsing error

### DIFF
--- a/pdf_extractor/__init__.py
+++ b/pdf_extractor/__init__.py
@@ -54,12 +54,23 @@ Output (Dict): A dictionary containing the key-value pairs:
         doc_info = self._pdfserv.extract(
             self._file_connector.get_absolute_path(file_path)
         )
-        result = {
-            "title": doc_info.title,
-            "sections": doc_info.sections,
-            "references": doc_info.references,
-            "tables": [table.astype(str).to_dict(orient="records") for table in doc_info.tables],
-            "text": doc_info.text,
-        }
+        
+        if (doc_info):
+            result = {
+                "title": doc_info.title,
+                "sections": doc_info.sections,
+                "references": doc_info.references,
+                "tables": [table.astype(str).to_dict(orient="records") for table in doc_info.tables],
+                "text": doc_info.text,
+            }
+        else:
+            result = {
+                "title": "",
+                "sections": [],
+                "references": [],
+                "tables": [],
+                "text": [],
+                "error": "There was a parsing problem with this document"
+            }
 
         return result


### PR DESCRIPTION
Check if the doc_info returned from the extractor is None, meaning there was a parsing error on the Adobe services side. Returns a blank document with an error field instead.